### PR TITLE
Allow examples to build

### DIFF
--- a/echo/device_headers/stm32l432xx.h
+++ b/echo/device_headers/stm32l432xx.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripherals registers hardware
   *
   ******************************************************************************
   * @attention

--- a/printf/device_headers/stm32l432xx.h
+++ b/printf/device_headers/stm32l432xx.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripherals registers hardware
   *
   ******************************************************************************
   * @attention

--- a/receive_irq/device_headers/stm32l432xx.h
+++ b/receive_irq/device_headers/stm32l432xx.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripherals registers hardware
   *
   ******************************************************************************
   * @attention

--- a/ringbuffer/device_headers/stm32l432xx.h
+++ b/ringbuffer/device_headers/stm32l432xx.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripherals registers hardware
   *
   ******************************************************************************
   * @attention


### PR DESCRIPTION
Fixes

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 458: invalid start byte
```